### PR TITLE
Refactor compute file with a meaningful name

### DIFF
--- a/compute/google-computeEngine.js
+++ b/compute/google-computeEngine.js
@@ -1,9 +1,9 @@
 const helpers = require('../helpers');
 const { checkParams } = helpers;
 
-class GoogleCompute {
+class GoogleComputeEngine {
   /**
-   * GoogleCompute constructor
+   * GoogleComputeEngine constructor
    * @constructor
    * @param {object} gogole - google SDK
    * @param {object} config - { projectId, keyFilename }
@@ -106,4 +106,4 @@ class GoogleCompute {
   }
 }
 
-module.exports = GoogleCompute;
+module.exports = GoogleComputeEngine;

--- a/gcp.js
+++ b/gcp.js
@@ -1,4 +1,4 @@
-const googleCompute = require("./compute/google");
+const googleCompute = require("./compute/google-computeEngine");
 const googleStorage = require("./storage/google-compute");
 const googleStorageBucket = require("./storage/google-storage");
 const googleDNS = require("./network/google-dns");

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const { datastore } = require("@google-cloud/datastore");
 const { dns } = require("@google-cloud/dns");
 const { storage } = require("@google-cloud/storage");
 
-const googleCompute = require("./compute/google");
+const googleCompute = require("./compute/google-computeEngine");
 const googleStorage = require("./storage/google-compute");
 const googleStorageBucket = require("./storage/google-storage");
 const googleDNS = require("./network/google-dns");


### PR DESCRIPTION
## Proposed Changes

  - The Google compute engine javascript file is named as `google.js `. I felt naming it `google.js` is not meaningful and it can be renamed in a more meaningful way.


